### PR TITLE
fix: hash search params correctly

### DIFF
--- a/util.ts
+++ b/util.ts
@@ -51,12 +51,7 @@ function baseUrlToFilename(url: URL): string {
 
 export function urlToFilename(url: URL) {
   const cacheFilename = baseUrlToFilename(url);
-  let restStr = url.pathname;
-  const query = url.search;
-  if (query) {
-    restStr += `?${query}`;
-  }
-  const hashedFilename = hash(restStr);
+  const hashedFilename = hash(url.pathname + url.search);
   return join(cacheFilename, hashedFilename);
 }
 

--- a/util_test.ts
+++ b/util_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "./deps_test.ts";
 
-import { hash } from "./util.ts";
+import { hash, urlToFilename } from "./util.ts";
 
 Deno.test({
   name: "hash test",
@@ -8,6 +8,26 @@ Deno.test({
     assertEquals(
       hash("hello world"),
       "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+    );
+  },
+});
+
+Deno.test({
+  name: "hash filename without search params",
+  fn() {
+    assertEquals(
+      urlToFilename(new URL("https://cdn.skypack.dev/svelte/internal")),
+      "https/cdn.skypack.dev/dae962c780900e18d25c9d22ed772d40dfcd93eb857d43c6e4f383f2c69ae40f",
+    );
+  },
+});
+
+Deno.test({
+  name: "hash filename with search params",
+  fn() {
+    assertEquals(
+      urlToFilename(new URL("https://cdn.skypack.dev/svelte/compiler?dts")),
+      "https/cdn.skypack.dev/0f37079a386379010b507f219d5e9e7b661a94f25a4b34742d589cf89847fc47",
     );
   },
 });


### PR DESCRIPTION
The `urlToFilename` was adding an extra `?` to the search query before hashing, causing the file names generated by `deno_graph` to not match the hashes generated by Deno itself. This should fix that issue. The two extra tests compare the `urlToFilename` function against real-world hashes generated by Deno.