### PR TITLE
feat: make compatible with Deno Deploy

### DIFF
--- a/deno_dir.ts
+++ b/deno_dir.ts
@@ -11,8 +11,11 @@ export class DenoDir {
   gen: DiskCache;
   root: string;
 
-  constructor(root?: string) {
+  constructor(root?: string | URL, readOnly = false) {
     if (root) {
+      if (root instanceof URL) {
+        root = root.toString();
+      }
       if (!isAbsolute(root)) {
         root = normalize(join(Deno.cwd(), root));
       }
@@ -42,7 +45,7 @@ export class DenoDir {
     Deno.permissions.request({ name: "read" });
     Deno.permissions.request({ name: "write", path: root });
     this.root = root;
-    this.deps = new HttpCache(join(root, "deps"));
+    this.deps = new HttpCache(join(root, "deps"), readOnly);
     this.gen = new DiskCache(join(root, "gen"));
   }
 }

--- a/deno_dir_test.ts
+++ b/deno_dir_test.ts
@@ -4,10 +4,10 @@ import { DenoDir } from "./deno_dir.ts";
 
 Deno.test({
   name: "DenoDir - basic",
-  fn() {
+  async fn() {
     const denoDir = new DenoDir();
     const url = new URL("https://deno.land/std@0.140.0/path/mod.ts");
-    const [file, headers] = denoDir.deps.get(url)!;
+    const [file, headers] = (await denoDir.deps.get(url))!;
     console.log(headers);
     file.close();
   },

--- a/file_fetcher.ts
+++ b/file_fetcher.ts
@@ -142,7 +142,7 @@ export class FileFetcher {
       throw new Deno.errors.Http("Too many redirects");
     }
 
-    const cached = this.#httpCache.get(specifier);
+    const cached = await this.#httpCache.get(specifier);
     if (!cached) {
       return undefined;
     }
@@ -186,7 +186,7 @@ export class FileFetcher {
     }
 
     const requestHeaders = new Headers();
-    const cached = this.#httpCache.get(specifier);
+    const cached = await this.#httpCache.get(specifier);
     if (cached) {
       const [file, cachedHeaders] = cached;
       file.close();

--- a/mod.ts
+++ b/mod.ts
@@ -1,17 +1,45 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import { FetchCacher } from "./cache.ts";
-import type { CacheType } from "./cache.ts";
-import type { CacheInfo, LoadResponse } from "./deps.ts";
-import { DenoDir } from "./deno_dir.ts";
-import { FileFetcher } from "./file_fetcher.ts";
-import type { CacheSetting } from "./file_fetcher.ts";
+/**
+ * A module which provides a TypeScript implementation of the Deno CLI's cache
+ * directory logic (`DENO_DIR`). This can be used in combination with other
+ * modules to provide user loadable APIs that are like the Deno CLI's
+ * functionality.
+ *
+ * This also can provide user read access in Deploy to a Deno CLI's cache when
+ * the cache is checked into the repository.
+ *
+ * ### Example
+ *
+ * ```ts
+ * import { createCache } from "https://deno.land/x/deno_cache/mod.ts";
+ * import { createGraph } from "https://deno.land/x/deno_graph/mod.ts";
+ *
+ * // create a cache where the location will be determined environmentally
+ * const cache = createCache();
+ * // destructuring the two functions we need to pass to the graph
+ * const { cacheInfo, load } = cache;
+ * // create a graph that will use the cache above to load and cache dependencies
+ * const graph = await createGraph("https://deno.land/x/oak@v9.0.1/mod.ts", {
+ *   cacheInfo,
+ *   load,
+ * });
+ *
+ * // log out the console a similar output to `deno info` on the command line.
+ * console.log(graph.toString());
+ * ```
+ *
+ * @module
+ */
 
-export { FetchCacher } from "./cache.ts";
-export type { CacheType } from "./cache.ts";
+import { type CacheType, FetchCacher } from "./cache.ts";
+import { type CacheInfo, type LoadResponse } from "./deps.ts";
+import { DenoDir } from "./deno_dir.ts";
+import { type CacheSetting, FileFetcher } from "./file_fetcher.ts";
+
+export { type CacheType, FetchCacher } from "./cache.ts";
 export { DenoDir } from "./deno_dir.ts";
-export { FileFetcher } from "./file_fetcher.ts";
-export type { CacheSetting } from "./file_fetcher.ts";
+export { type CacheSetting, FileFetcher } from "./file_fetcher.ts";
 
 export interface Loader {
   /** A function that can be passed to a `deno_graph` building function to
@@ -26,15 +54,27 @@ export interface Loader {
 
 export interface Cacher {
   /** Retrieve a specific type of cached resource from the disk cache. */
-  get(type: CacheType, specifier: string): string | undefined;
+  get(type: CacheType, specifier: string): Promise<string | undefined>;
   /** Set a specific type of cached resource to the disk cache. */
-  set(type: CacheType, specifier: string, value: string): void;
+  set(type: CacheType, specifier: string, value: string): Promise<void>;
 }
 
 export interface CacheOptions {
+  /** Allow remote URLs to be fetched if missing from the cache. This defaults
+   * to `true`. Setting it to `false` is like passing the `--no-remote` in the
+   * Deno CLI, meaning that any modules not in cache error. */
   allowRemote?: boolean;
+  /** Determines how the cache will be used. The default value is `"use"`
+   * meaning the cache will be used, and any remote module cache misses will
+   * be fetched and stored in the cache. */
   cacheSetting?: CacheSetting;
-  root?: string;
+  /** This forces the cache into a `readOnly` mode, where fetched resources
+   * will not be stored on disk if `true`. The default is detected from the
+   * environment, checking to see if `Deno.writeFile` exists. */
+  readOnly?: boolean;
+  /** Specifies a path to the root of the cache. Setting this value overrides
+   * the detection of location from the environment. */
+  root?: string | URL;
 }
 
 /**
@@ -42,9 +82,16 @@ export interface CacheOptions {
  * structure for remote dependencies and cached output of emitted modules.
  */
 export function createCache(
-  { root, cacheSetting = "use", allowRemote = true }: CacheOptions = {},
+  { root, cacheSetting = "use", allowRemote = true, readOnly }: CacheOptions =
+    {},
 ): Loader & Cacher {
-  const denoDir = new DenoDir(root);
+  if (readOnly === undefined) {
+    // this detects when we are running in environments like Deno Deploy where
+    // the `Deno.writeFile` is not available.
+    readOnly = !("Deno" in globalThis && "writeFile" in Deno &&
+      typeof Deno.writeFile === "function");
+  }
+  const denoDir = new DenoDir(root, readOnly);
   const fileFetcher = new FileFetcher(denoDir.deps, cacheSetting, allowRemote);
-  return new FetchCacher(denoDir.gen, denoDir.deps, fileFetcher);
+  return new FetchCacher(denoDir.gen, denoDir.deps, fileFetcher, readOnly);
 }

--- a/util.ts
+++ b/util.ts
@@ -12,7 +12,7 @@ export function assert(cond: unknown, msg = "Assertion failed."): asserts cond {
 
 /**
  * Generates a sha256 hex hash for a given input string.  This mirrors the
- * behaviour of Deno CLI's `cli::checksum::gen`.
+ * behavior of Deno CLI's `cli::checksum::gen`.
  *
  * Would love to use the Crypto API here, but it only works async and we need
  * to be able to generate the hashes sync to be able to keep the cache able to
@@ -58,6 +58,18 @@ export function urlToFilename(url: URL) {
   }
   const hashedFilename = hash(restStr);
   return join(cacheFilename, hashedFilename);
+}
+
+export async function isFile(filePath: string): Promise<boolean> {
+  try {
+    const stats = await Deno.lstat(filePath);
+    return stats.isFile;
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw err;
+  }
 }
 
 export function isFileSync(filePath: string): boolean {


### PR DESCRIPTION
Closes #7

This makes a breaking change to the `Cacher` interface, in that the
`.get()` and `.set()` methods now work asynchronously. Also, because
the `.cacheInfo()` method is specified in `deno_graph` it is currently
not compatible with Deno Deploy, as it needs to be able to read
information asynchronously.