### PR TITLE
fix: properly detect readonly environments

### DIFF
--- a/cache.ts
+++ b/cache.ts
@@ -31,7 +31,7 @@ export class FetchCacher {
   #diskCache: DiskCache;
   #fileFetcher: FileFetcher;
   #httpCache: HttpCache;
-  #readOnly: boolean;
+  #readOnly!: boolean;
 
   async #getEmitMetadata(specifier: URL): Promise<EmitMetadata | undefined> {
     const filename = DiskCache.getCacheFilenameWithExtension(specifier, "meta");
@@ -55,12 +55,19 @@ export class FetchCacher {
     diskCache: DiskCache,
     httpCache: HttpCache,
     fileFetcher: FileFetcher,
-    readOnly: boolean,
+    readOnly?: boolean,
   ) {
     this.#diskCache = diskCache;
     this.#fileFetcher = fileFetcher;
     this.#httpCache = httpCache;
-    this.#readOnly = readOnly;
+    if (readOnly === undefined) {
+      (async () => {
+        this.#readOnly =
+          (await Deno.permissions.query({ name: "write" })).state === "denied";
+      })();
+    } else {
+      this.#readOnly = readOnly;
+    }
   }
 
   /** Provides information about the state of the cache, which is used by

--- a/deno_dir.ts
+++ b/deno_dir.ts
@@ -11,7 +11,7 @@ export class DenoDir {
   gen: DiskCache;
   root: string;
 
-  constructor(root?: string | URL, readOnly = false) {
+  constructor(root?: string | URL, readOnly?: boolean) {
     if (root) {
       if (root instanceof URL) {
         root = root.toString();

--- a/deno_dir.ts
+++ b/deno_dir.ts
@@ -43,7 +43,6 @@ export class DenoDir {
     assert(root, "Could not set the Deno root directory");
     assert(isAbsolute(root), `The root directory "${root}" is not absolute.`);
     Deno.permissions.request({ name: "read" });
-    Deno.permissions.request({ name: "write", path: root });
     this.root = root;
     this.deps = new HttpCache(join(root, "deps"), readOnly);
     this.gen = new DiskCache(join(root, "gen"));

--- a/http_cache.ts
+++ b/http_cache.ts
@@ -38,9 +38,9 @@ class Metadata {
 
 export class HttpCache {
   location: string;
-  readOnly: boolean;
+  readOnly?: boolean;
 
-  constructor(location: string, readOnly: boolean) {
+  constructor(location: string, readOnly?: boolean) {
     assert(isAbsolute(location));
     this.location = location;
     this.readOnly = readOnly;
@@ -72,6 +72,12 @@ export class HttpCache {
     headers: Record<string, string>,
     content: string,
   ): Promise<void> {
+    if (this.readOnly === undefined) {
+      this.readOnly =
+        (await Deno.permissions.query({ name: "write" })).state === "denied"
+          ? true
+          : false;
+    }
     if (this.readOnly) {
       return;
     }

--- a/mod.ts
+++ b/mod.ts
@@ -85,12 +85,6 @@ export function createCache(
   { root, cacheSetting = "use", allowRemote = true, readOnly }: CacheOptions =
     {},
 ): Loader & Cacher {
-  if (readOnly === undefined) {
-    // this detects when we are running in environments like Deno Deploy where
-    // the `Deno.writeFile` is not available.
-    readOnly = !("Deno" in globalThis && "writeFile" in Deno &&
-      typeof Deno.writeFile === "function");
-  }
   const denoDir = new DenoDir(root, readOnly);
   const fileFetcher = new FileFetcher(denoDir.deps, cacheSetting, allowRemote);
   return new FetchCacher(denoDir.gen, denoDir.deps, fileFetcher, readOnly);


### PR DESCRIPTION
This should get deno_cache working on Deno Deploy.