### PR TITLE
fix: AuthTokens

### DIFF
--- a/auth_tokens.ts
+++ b/auth_tokens.ts
@@ -28,7 +28,7 @@ export function splitLast(
 
 function tokenAsValue(authToken: AuthToken): string {
   return authToken.type === "basic"
-    ? `Basic ${authToken.username}:${authToken.password}`
+    ? `Basic ${btoa(`${authToken.username}:${authToken.password}`)}`
     : `Bearer ${authToken.token}`;
 }
 
@@ -38,9 +38,9 @@ export class AuthTokens {
     const tokens: AuthToken[] = [];
     for (const tokenStr of tokensStr.split(";").filter((s) => s.length > 0)) {
       if (tokensStr.includes("@")) {
-        const [host, token] = splitLast(tokenStr, "@");
+        const [token, host] = splitLast(tokenStr, "@");
         if (token.includes(":")) {
-          const [password, username] = splitLast(token, ":");
+          const [username, password] = splitLast(token, ":");
           tokens.push({ type: "basic", host, username, password });
         } else {
           tokens.push({ type: "bearer", host, token });

--- a/auth_tokens_test.ts
+++ b/auth_tokens_test.ts
@@ -10,3 +10,20 @@ Deno.test({
     assertEquals(authTokens.get(new URL("http://localhost")), undefined);
   },
 });
+
+Deno.test({
+  name: "find bearer token",
+  fn() {
+    const authTokens = new AuthTokens('token1@example.com');
+    assertEquals(authTokens.get(new URL("https://example.com")), 'Bearer token1');
+  },
+});
+
+Deno.test({
+  name: "find basic token (base64 encoded)",
+  fn() {
+    const authTokens = new AuthTokens('user1:pw1@example.com');
+    assertEquals(authTokens.get(new URL("https://example.com")), 'Basic dXNlcjE6cHcx');
+  },
+});
+

--- a/auth_tokens_test.ts
+++ b/auth_tokens_test.ts
@@ -14,16 +14,21 @@ Deno.test({
 Deno.test({
   name: "find bearer token",
   fn() {
-    const authTokens = new AuthTokens('token1@example.com');
-    assertEquals(authTokens.get(new URL("https://example.com")), 'Bearer token1');
+    const authTokens = new AuthTokens("token1@example.com");
+    assertEquals(
+      authTokens.get(new URL("https://example.com")),
+      "Bearer token1",
+    );
   },
 });
 
 Deno.test({
   name: "find basic token (base64 encoded)",
   fn() {
-    const authTokens = new AuthTokens('user1:pw1@example.com');
-    assertEquals(authTokens.get(new URL("https://example.com")), 'Basic dXNlcjE6cHcx');
+    const authTokens = new AuthTokens("user1:pw1@example.com");
+    assertEquals(
+      authTokens.get(new URL("https://example.com")),
+      "Basic dXNlcjE6cHcx",
+    );
   },
 });
-


### PR DESCRIPTION
- Swap token & host from string split
- Swap username & password from string split
- Base64 encode basic auth values
- Added tests

fixes #17 