### PR TITLE
Implied readonly fix

### DIFF
--- a/file_fetcher_test.ts
+++ b/file_fetcher_test.ts
@@ -28,7 +28,7 @@ Deno.test({
   },
   async fn() {
     const denoDir = new DenoDir();
-    const fileFetcher = new FileFetcher(denoDir.deps, 'reloadAll');
+    const fileFetcher = new FileFetcher(denoDir.deps, "reloadAll");
     await fileFetcher.fetch(new URL("https://deno.land/x/oak@v10.5.1/mod.ts"));
   },
 });

--- a/file_fetcher_test.ts
+++ b/file_fetcher_test.ts
@@ -17,3 +17,18 @@ Deno.test({
     console.log(graph.toString());
   },
 });
+
+Deno.test({
+  name: "FileFetcher assumes readonly from permissions",
+  permissions: {
+    env: true,
+    net: true,
+    read: true,
+    write: false,
+  },
+  async fn() {
+    const denoDir = new DenoDir();
+    const fileFetcher = new FileFetcher(denoDir.deps, 'reloadAll');
+    await fileFetcher.fetch(new URL("https://deno.land/x/oak@v10.5.1/mod.ts"));
+  },
+});

--- a/http_cache.ts
+++ b/http_cache.ts
@@ -73,7 +73,8 @@ export class HttpCache {
     content: string,
   ): Promise<void> {
     if (this.readOnly === undefined) {
-      const writeState = (await Deno.permissions.query({ name: "write" })).state;
+      const writeState =
+        (await Deno.permissions.query({ name: "write" })).state;
       this.readOnly = writeState === "denied" || writeState === "prompt";
     }
     if (this.readOnly) {

--- a/http_cache.ts
+++ b/http_cache.ts
@@ -73,10 +73,8 @@ export class HttpCache {
     content: string,
   ): Promise<void> {
     if (this.readOnly === undefined) {
-      this.readOnly =
-        (await Deno.permissions.query({ name: "write" })).state === "denied"
-          ? true
-          : false;
+      const writeState = (await Deno.permissions.query({ name: "write" })).state;
+      this.readOnly = writeState === "denied" || writeState === "prompt";
     }
     if (this.readOnly) {
       return;


### PR DESCRIPTION
Fixes #20 

Added test for implied readonly.
Fixed HttpCache to imply readonly for a write state of 'prompt' (in addition to 'denied').
