### PR TITLE
Bump the standard library to v180

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -2,9 +2,9 @@
 
 // std library dependencies
 
-export { ensureDir } from "https://deno.land/std@0.140.0/fs/ensure_dir.ts";
-export * as colors from "https://deno.land/std@0.140.0/fmt/colors.ts";
-export { Sha256 } from "https://deno.land/std@0.140.0/hash/sha256.ts";
+export { ensureDir } from "https://deno.land/std@0.180.0/fs/ensure_dir.ts";
+export * as colors from "https://deno.land/std@0.180.0/fmt/colors.ts";
+export { Sha256 } from "https://deno.land/std@0.160.0/hash/sha256.ts";
 export {
   dirname,
   extname,
@@ -13,11 +13,11 @@ export {
   join,
   normalize,
   sep,
-} from "https://deno.land/std@0.140.0/path/mod.ts";
+} from "https://deno.land/std@0.180.0/path/mod.ts";
 export {
   readAll,
   writeAll,
-} from "https://deno.land/std@0.140.0/streams/conversion.ts";
+} from "https://deno.land/std@0.180.0/streams/mod.ts";
 
 // type only dependencies of `deno_graph`
 

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,4 +1,4 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-export { assertEquals } from "https://deno.land/std@0.140.0/testing/asserts.ts";
+export { assertEquals } from "https://deno.land/std@0.180.0/testing/asserts.ts";
 export { createGraph } from "https://deno.land/x/deno_graph@0.26.0/mod.ts";


### PR DESCRIPTION
## What does this change?

Bumps the standard library to v180.

## Known issues

The std/hash module needs to be kept at v160, because it exports a synchronous implementation of the SHA256 algorithm. Later versions do not export this module.