### PR TITLE
fix: export deno_graph types for eszip

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -26,7 +26,6 @@ export type {
   LoadResponse,
 } from "https://deno.land/x/deno_graph@0.66.0/mod.ts";
 export type {
-  LoadResponseModule,
   LoadResponseExternal,
+  LoadResponseModule,
 } from "https://deno.land/x/deno_graph@0.66.0/types.ts";
-

--- a/deps.ts
+++ b/deps.ts
@@ -25,3 +25,8 @@ export type {
   CacheInfo,
   LoadResponse,
 } from "https://deno.land/x/deno_graph@0.66.0/mod.ts";
+export type {
+  LoadResponseModule,
+  LoadResponseExternal,
+} from "https://deno.land/x/deno_graph@0.66.0/types.ts";
+

--- a/mod.ts
+++ b/mod.ts
@@ -51,10 +51,13 @@ export interface Loader {
    */
   load(
     specifier: string,
-    _isDynamic?: boolean,
+    isDynamic?: boolean,
     cacheSetting?: CacheSetting,
+    checksum?: string,
   ): Promise<LoadResponse | undefined>;
 }
+
+export type { LoadResponse, LoadResponseModule, LoadResponseExternal } from "./deps.ts";
 
 export interface CacheOptions {
   /** Allow remote URLs to be fetched if missing from the cache. This defaults

--- a/mod.ts
+++ b/mod.ts
@@ -57,7 +57,11 @@ export interface Loader {
   ): Promise<LoadResponse | undefined>;
 }
 
-export type { LoadResponse, LoadResponseModule, LoadResponseExternal } from "./deps.ts";
+export type {
+  LoadResponse,
+  LoadResponseExternal,
+  LoadResponseModule,
+} from "./deps.ts";
 
 export interface CacheOptions {
   /** Allow remote URLs to be fetched if missing from the cache. This defaults


### PR DESCRIPTION
These types can be re-used in eszip.