### PR TITLE
fix: do not retry 4xx status codes

### DIFF
--- a/file_fetcher.ts
+++ b/file_fetcher.ts
@@ -328,7 +328,7 @@ export async function fetchWithRetries(
     iterationCount++;
     try {
       const res = await fetch(url, init);
-      if (res.ok || iterationCount > maxRetries || res.status === 404) {
+      if (res.ok || iterationCount > maxRetries || res.status >= 400 && res.status < 500) {
         return res;
       }
     } catch (err) {

--- a/file_fetcher.ts
+++ b/file_fetcher.ts
@@ -328,6 +328,9 @@ export async function fetchWithRetries(
     iterationCount++;
     try {
       const res = await fetch(url, init);
+      if (res.status === 404) {
+        return res;
+      }
       if (res.ok || iterationCount > maxRetries) {
         return res;
       }

--- a/file_fetcher.ts
+++ b/file_fetcher.ts
@@ -328,7 +328,10 @@ export async function fetchWithRetries(
     iterationCount++;
     try {
       const res = await fetch(url, init);
-      if (res.ok || iterationCount > maxRetries || res.status >= 400 && res.status < 500) {
+      if (
+        res.ok || iterationCount > maxRetries ||
+        res.status >= 400 && res.status < 500
+      ) {
         return res;
       }
     } catch (err) {

--- a/file_fetcher.ts
+++ b/file_fetcher.ts
@@ -328,10 +328,7 @@ export async function fetchWithRetries(
     iterationCount++;
     try {
       const res = await fetch(url, init);
-      if (res.status === 404) {
-        return res;
-      }
-      if (res.ok || iterationCount > maxRetries) {
+      if (res.ok || iterationCount > maxRetries || res.status === 404) {
         return res;
       }
     } catch (err) {


### PR DESCRIPTION
Kind of think we shouldn't be retrying for more status codes, but I'm not sure what's best here. Basically we only want to retry for transient errors.